### PR TITLE
Handle URL imports

### DIFF
--- a/lib/counter.js
+++ b/lib/counter.js
@@ -1,5 +1,6 @@
 /* jshint eqnull:true */
 var fs = require('fs');
+var path = require('path');
 
 // Thanks jshint! :)
 /**
@@ -25,6 +26,21 @@ function removeComments(str) {
     return str;
 }
 
+function importFiles (filePath, file) {
+    var importStatements = file.match(/(@import)(.+?)(;)/gim, "$2}");
+
+    importStatements.map(function (importStatement) {
+        var importFilePath = importStatement
+            .replace(" ", "")
+            .replace(/(@import)(.+?)(;)/gim, "$2")
+            .replace(/(url\()(.+?)(\))/gim, "$2")
+            .replace(/['"]+/g, '');
+        var importedCss = fs.readFileSync(path.resolve(path.dirname(filePath), importFilePath), {encoding: "UTF-8"});
+        file = file.replace(importStatement, importedCss);
+    });
+    return file;
+}
+
 var exports = {
     count: function (file) {
         var tmp,
@@ -46,6 +62,7 @@ var exports = {
             // .replace(/,/gim, ",\n")
             // .replace(/\n{2,}/gim, "\n")
             ;
+        input = importFiles(file, input);
 
         return input.match(/\{/gim).length +
             ((tmp = input.match(/,/gim)) == null ? 0 : tmp.length) -

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -29,15 +29,18 @@ function removeComments(str) {
 function importFiles (filePath, file) {
     var importStatements = file.match(/(@import)(.+?)(;)/gim, "$2}");
 
-    importStatements.map(function (importStatement) {
-        var importFilePath = importStatement
-            .replace(" ", "")
-            .replace(/(@import)(.+?)(;)/gim, "$2")
-            .replace(/(url\()(.+?)(\))/gim, "$2")
-            .replace(/['"]+/g, '');
-        var importedCss = fs.readFileSync(path.resolve(path.dirname(filePath), importFilePath), {encoding: "UTF-8"});
-        file = file.replace(importStatement, importedCss);
-    });
+    if (importStatements) {
+        importStatements.map(function (importStatement) {
+            var importFilePath = importStatement
+                .replace(" ", "")
+                .replace(/(@import)(.+?)(;)/gim, "$2")
+                .replace(/(url\()(.+?)(\))/gim, "$2")
+                .replace(/['"]+/g, '');
+            var importedCss = fs.readFileSync(path.resolve(path.dirname(filePath), importFilePath), {encoding: "UTF-8"});
+            file = file.replace(importStatement, importedCss);
+        });
+    }
+
     return file;
 }
 

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -20,7 +20,7 @@ function removeComments(str) {
     str = str || "";
 
     str = str.replace(/\/\*(?:(?!\*\/)[\s\S])*\*\//g, "");
-    str = str.replace(/\/\/[^\n\r]*/g, ""); // Everything after '//'
+	str = str.replace(/(^|[^:])\/\/[^\n\r]*/g, "$1"); // Everything after '//' except import URLs
 
     return str;
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CSS selector counter as seen by IE9",
   "main": "./lib/counter.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha test/*.js"
   },
   "repository": {
     "type": "git",
@@ -23,5 +23,8 @@
     "grunt": "~0.4.1",
     "grunt-release": "~0.3.3",
     "grunt-contrib-connect": "~0.3.0"
+  },
+  "dependencies": {
+    "mocha": "^2.1.0"
   }
 }

--- a/test/counterTests.js
+++ b/test/counterTests.js
@@ -1,0 +1,10 @@
+var assert = require('assert')
+var counter = require('../lib/counter');
+var path = require('path');
+
+describe("counter", function () {
+	it("processes imports as expected", function () {
+		var count = counter.count(path.resolve(__dirname, "./testFiles/root.css"));
+		assert.equal(count, 3, "After importing there should be 3 selectors. Count = " + count);
+	});
+});

--- a/test/testFiles/a.css
+++ b/test/testFiles/a.css
@@ -1,0 +1,3 @@
+.class2 {
+    margin: 5px;
+}

--- a/test/testFiles/b.css
+++ b/test/testFiles/b.css
@@ -1,0 +1,3 @@
+.class3 {
+    margin: 5px;
+}

--- a/test/testFiles/root.css
+++ b/test/testFiles/root.css
@@ -1,0 +1,6 @@
+@import url("./b.css");
+@import "a.css";
+
+.class1 {
+    font-size: 14px;
+}


### PR DESCRIPTION
Fully qualified URLs in import statements:
@import "http://www.somedomain.com/some-external.css";

were being caught by the comment removal function and causing:

ie9-selector-counter/lib/counter.js:50
        return input.match(/{/gim).length +
                                   ^
TypeError: Cannot read property 'length' of null
    at Object.exports.count (/Users/edward.glen/Projects/ie9-selector-counter/lib/counter.js:50:36)

This change avoids removal of URLs, keeping the modified css valid.
